### PR TITLE
Handle zero-length symbol names in patterns

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -51,7 +51,9 @@
 ) ;; End of eval-when
 
 (defun varsymp (x)
-  (and (symbolp x) (eql (char (symbol-name x) 0) #\?)))
+  (and (symbolp x)
+       (plusp (length (symbol-name x)))
+       (eql (char (symbol-name x) 0) #\?)))
 
 (defun binding (x binds)
   (labels ((recbind (x binds)


### PR DESCRIPTION
Symbols with a zero-length name (e.g. the keyword symbol `:||`) break tests. For example:

``` lisp
> (keywordp :||)
T
```

``` lisp
> (macroexpand-1 '(eos:is (keywordp :||)))
debugger invoked on a SB-INT:INVALID-ARRAY-INDEX-ERROR in thread
#<THREAD "main thread" RUNNING {10029A8D03}>:
  Index 0 out of bounds for (SIMPLE-ARRAY CHARACTER
                             (0)), should be nonnegative and <0.
...
```

This happens because the pattern matcher feeds everything to `varsymp`, but `varsymp` doesn't expect symbol names to not have a first character:

``` lisp
> (eos::varsymp :||)
debugger invoked on a SB-INT:INVALID-ARRAY-INDEX-ERROR in thread
#<THREAD "main thread" RUNNING {10029A8D03}>:
  Index 0 out of bounds for (SIMPLE-ARRAY CHARACTER
                             (0)), should be nonnegative and <0.
...
```

I've made the obvious fix to have it check the length first, so the above now work as expected:

``` lisp
> (eos::varsymp :||)
NIL
```

``` lisp
> (macroexpand-1 '(eos:is (keywordp :||)))
(LET ((#:V1116 :||))
  (IF (KEYWORDP #:V1116)
...
T
```
