### PR TITLE
Fix UB of destructively modifying macro arguments

### DIFF
--- a/src/test.lisp
+++ b/src/test.lisp
@@ -47,7 +47,11 @@ FIXTURE specifies a fixtrue to wrap the body in."
          (suite-arg (getf (cdr (ensure-list name)) :suite tmp))
          (suite-form (if (eq tmp suite-arg) '*suite*
                          `(get-test ',suite-arg))))
-    (when (consp name) (remf (cdr name) :suite))
+    (when (consp name)
+      ;; Copy `name' so we don't modify macro arguments destructively
+      (let ((name* (copy-list name)))
+        (remf (cdr name*) :suite)
+        (setf name name*)))
     (destructuring-bind
           (name &key depends-on (compile-at :run-time) fixture)
         (ensure-list name)


### PR DESCRIPTION
This was detected by a warning on the upcoming SBCL 2.0.7.
Causing optima.test to fail to load
http://report.quicklisp.org/2020-07-24/failure-report/optima.html#optima.test
